### PR TITLE
Publish packages in CI and update to crossplane-contrib orgs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
-  DOCKER_USR: ${{ secrets.DOCKER_USR }}
+  CONTRIB_DOCKER_USR: ${{ secrets.CONTRIB_DOCKER_USR }}
   XPKG_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
   AWS_USR: ${{ secrets.AWS_USR }}
 
@@ -304,10 +304,10 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: env.DOCKER_USR != ''
+        if: env.CONTRIB_DOCKER_USR != ''
         with:
-          username: ${{ secrets.DOCKER_USR }}
-          password: ${{ secrets.DOCKER_PSW }}
+          username: ${{ secrets.CONTRIB_DOCKER_USR }}
+          password: ${{ secrets.CONTRIB_DOCKER_PSW }}
 
       - name: Login to Upbound
         uses: docker/login-action@v1
@@ -319,7 +319,7 @@ jobs:
 
       - name: Publish Artifacts to S3, DockerHub
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
-        if: env.AWS_USR != '' && env.DOCKER_USR != ''
+        if: env.AWS_USR != '' && env.CONTRIB_DOCKER_USR != ''
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
@@ -329,7 +329,7 @@ jobs:
           DOCS_GIT_PSW: ${{ secrets.UPBOUND_BOT_GITHUB_PSW }}
 
       - name: Promote Artifacts in S3, DockerHub
-        if: github.ref == 'refs/heads/master' && env.AWS_USR != '' && env.DOCKER_USR != ''
+        if: github.ref == 'refs/heads/master' && env.AWS_USR != '' && env.CONTRIB_DOCKER_USR != ''
         run: make -j2 promote
         env:
           BRANCH_NAME: master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ env:
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
   DOCKER_USR: ${{ secrets.DOCKER_USR }}
+  XPKG_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}
   AWS_USR: ${{ secrets.AWS_USR }}
 
 jobs:
@@ -307,6 +308,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USR }}
           password: ${{ secrets.DOCKER_PSW }}
+
+      - name: Login to Upbound
+        uses: docker/login-action@v1
+        if: env.XPKG_ACCESS_ID != ''
+        with:
+          registry: xpkg.upbound.io
+          username: ${{ secrets.XPKG_ACCESS_ID }}
+          password: ${{ secrets.XPKG_TOKEN }}
 
       - name: Publish Artifacts to S3, DockerHub
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}

--- a/.github/workflows/configurations.yml
+++ b/.github/workflows/configurations.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DOCKER_USR: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
+  CONTRIB_DOCKER_USR: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
 
 jobs:
   getting-started-with-aws:
@@ -26,7 +26,7 @@ jobs:
         id: tagger
       - name: Login to Docker
         uses: docker/login-action@v1
-        if: env.DOCKER_USR != ''
+        if: env.CONTRIB_DOCKER_USR != ''
         with:
           registry: registry.upbound.io
           username: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
@@ -55,7 +55,7 @@ jobs:
         id: tagger
       - name: Login to Docker
         uses: docker/login-action@v1
-        if: env.DOCKER_USR != ''
+        if: env.CONTRIB_DOCKER_USR != ''
         with:
           registry: registry.upbound.io
           username: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
@@ -84,7 +84,7 @@ jobs:
         id: tagger
       - name: Login to Docker
         uses: docker/login-action@v1
-        if: env.DOCKER_USR != ''
+        if: env.CONTRIB_DOCKER_USR != ''
         with:
           registry: registry.upbound.io
           username: ${{ secrets.UPBOUND_XP_ROBOT_USR }}
@@ -113,7 +113,7 @@ jobs:
         id: tagger
       - name: Login to Docker
         uses: docker/login-action@v1
-        if: env.DOCKER_USR != ''
+        if: env.CONTRIB_DOCKER_USR != ''
         with:
           registry: registry.upbound.io
           username: ${{ secrets.UPBOUND_XP_ROBOT_USR }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -15,7 +15,7 @@ env:
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
   # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
   # credentials have been provided before trying to run steps that need them.
-  DOCKER_USR: ${{ secrets.DOCKER_USR }}
+  CONTRIB_DOCKER_USR: ${{ secrets.CONTRIB_DOCKER_USR }}
   AWS_USR: ${{ secrets.AWS_USR }}
 
 jobs:
@@ -33,13 +33,13 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
-        if: env.DOCKER_USR != ''
+        if: env.CONTRIB_DOCKER_USR != ''
         with:
-          username: ${{ secrets.DOCKER_USR }}
-          password: ${{ secrets.DOCKER_PSW }}
+          username: ${{ secrets.CONTRIB_DOCKER_USR }}
+          password: ${{ secrets.CONTRIB_DOCKER_PSW }}
 
       - name: Promote Artifacts in S3, DockerHub, and Upbound Registry
-        if: env.AWS_USR != '' && env.DOCKER_USR != ''
+        if: env.AWS_USR != '' && env.CONTRIB_DOCKER_USR != ''
         run: make -j2 promote BRANCH_NAME=${GITHUB_REF##*/}
         env:
           VERSION: ${{ github.event.inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ IMAGES = provider-argocd
 # ====================================================================================
 # Setup XPKG
 
-XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane-contrib index.docker.io/crossplane-contrib
+XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane-contrib index.docker.io/crossplanecontrib
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
 # inferred.
 XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane-contrib

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ IMAGES = provider-argocd
 # ====================================================================================
 # Setup XPKG
 
-XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane index.docker.io/crossplane
+XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane-contrib index.docker.io/crossplane-contrib
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
 # inferred.
-XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane
+XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane-contrib
 XPKGS = provider-argocd
 -include build/makelib/xpkg.mk
 

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -3,20 +3,16 @@ kind: Provider
 metadata:
   name: provider-argocd
   annotations:
-    company: Crossplane
-    maintainer: Crossplane Maintainers <info@crossplane.io>
-    source: github.com/crossplane-contrib/provider-argocd
-    license: Apache-2.0
-    descriptionShort: |
+    meta.crossplane.io/maintainer: Crossplane Maintainers <info@crossplane.io>
+    meta.crossplane.io/source: github.com/crossplane-contrib/provider-argocd
+    meta.crossplane.io/license: Apache-2.0
+    meta.crossplane.io/description: |
       The argocd Crossplane provider enables resources management for argocd.
-    description: |
-      The argocd Crossplane provider adds support for
-      managing argocd resources in Kubernetes.
-    readme: |
+    meta.crossplane.io/readme: |
       `provider-argocd` is the Crossplane infrastructure provider for
       [argocd](https://argocd.com/).
       Available resources and their fields can be found in the [CRD
-      Docs](https://doc.crds.dev/github.com/crossplane-contrib/provider-argocd).
+      Docs](https://marketplace.upbound.io/providers/crossplane-contrib/provider-argocd/latest/crds).
       If you encounter an issue please reach out on
       [slack.crossplane.io](https://slack.crossplane.io) and create an issue in
       the [crossplane-contrib/provider-argocd](https://github.com/crossplane-contrib/provider-argocd)


### PR DESCRIPTION
Signed-off-by: Jason Tang <jason@upbound.io>

### Description of your changes
Update the CI to publish to `crossplane-contrib` OCI repos in both DockerHub and Upbound registries.

xref https://github.com/crossplane/crossplane/issues/3350

Also updates `crossplane.yaml` to use the updated metadata annotations per the xpkg spec so the package will render nicely in the Upbound Marketplace.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

*Publish*
```
➜  provider-argocd git:(jastang-update-ci-publish) ✗ VERSION=v0.1.1 BRANCH_NAME=master make -j2 publish
10:06:52 [ .. ] Pushing package xpkg.upbound.io/jastang/provider-argocd:v0.1.1
10:06:52 [ .. ] Skipping image publish for docker.io/provider-argocd:v0.1.1
Publish is deferred to xpkg machinery
10:06:52 [ OK ] Image publish skipped for docker.io/provider-argocd:v0.1.1
xpkg pushed to xpkg.upbound.io/jastang/provider-argocd:v0.1.1
10:07:04 [ OK ] Pushed package xpkg.upbound.io/jastang/provider-argocd:v0.1.1
```

*Verify*
```
➜  provider-argocd git:(jastang-update-ci-publish) crane manifest xpkg.upbound.io/jastang/provider-argocd:v0.1.1 | jq .
{
  "schemaVersion": 2,
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1005,
      "digest": "sha256:0a99f80d95dbd4196b18482eef1f84b5407599cf276a75c03ea2b3c39cbda395",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1005,
      "digest": "sha256:3b14ebdc36c23ccb892ab52feb7934f3016e55262f3a14d39a6a24655edc534c",
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    }
  ]
}
```

[contribution process]: https://git.io/fj2m9
