### PR TITLE
Add support for Filesystem credentials.

### DIFF
--- a/apis/v1alpha1/providerconfig_types.go
+++ b/apis/v1alpha1/providerconfig_types.go
@@ -24,14 +24,14 @@ import (
 
 // A ProviderConfigSpec defines the desired state of a ProviderConfig.
 type ProviderConfigSpec struct {
-	// ServerAddr of the argocd instance
+	// ServerAddr is the hostname or IP of the argocd instance
 	ServerAddr string `json:"serverAddr"`
 
-	// PlainText specifies whether to use http vs https
+	// PlainText specifies whether to use http vs https. Default: false.
 	// +optional
 	PlainText *bool `json:"plainText,omitempty"`
 
-	// Insecure specifies whether to disable strict tls validation
+	// Insecure specifies whether to disable strict tls validation. Default: false.
 	// +optional
 	Insecure *bool `json:"insecure,omitempty"`
 
@@ -42,7 +42,7 @@ type ProviderConfigSpec struct {
 // ProviderCredentials required to authenticate.
 type ProviderCredentials struct {
 	// Source of the provider credentials.
-	// +kubebuilder:validation:Enum=None;Secret;Environment
+	// +kubebuilder:validation:Enum=None;Secret;Environment;Filesystem
 	Source xpv1.CredentialsSource `json:"source"`
 
 	xpv1.CommonCredentialSelectors `json:",inline"`

--- a/package/crds/argocd.crossplane.io_providerconfigs.yaml
+++ b/package/crds/argocd.crossplane.io_providerconfigs.yaml
@@ -96,18 +96,21 @@ spec:
                     - None
                     - Secret
                     - Environment
+                    - Filesystem
                     type: string
                 required:
                 - source
                 type: object
               insecure:
-                description: Insecure specifies whether to disable strict tls validation
+                description: 'Insecure specifies whether to disable strict tls validation.
+                  Default: false.'
                 type: boolean
               plainText:
-                description: PlainText specifies whether to use http vs https
+                description: 'PlainText specifies whether to use http vs https. Default:
+                  false.'
                 type: boolean
               serverAddr:
-                description: ServerAddr of the argocd instance
+                description: ServerAddr is the hostname or IP of the argocd instance
                 type: string
             required:
             - credentials

--- a/pkg/controller/cluster/controller.go
+++ b/pkg/controller/cluster/controller.go
@@ -108,7 +108,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	observedCluster, err := e.client.Get(ctx, &clusterQuery)
 	if cluster.IsErrorClusterNotFound(err) ||
-		(meta.WasDeleted(mg) && meta.GetExternalName(cr) != observedCluster.Name) {
+		(err == nil && meta.WasDeleted(mg) && meta.GetExternalName(cr) != observedCluster.Name) {
 		// ArgoCD Cluster resource ignores the name field. This detects the deletion of the default cluster resource.
 		return managed.ExternalObservation{}, nil
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #30

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.
        But it didn't work.

```
13:56:16 [ .. ] golangci-lint
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt

goroutine 1 [running]:
github.com/go-critic/go-critic/checkers.init.22()
        github.com/go-critic/go-critic@v0.6.3/checkers/embedded_rules.go:47 +0x4b4
13:56:23 [FAIL]
```

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I tested it in my own environment, where it was able to receive an ArgoCD token from Vault, authenticate to the ArgoCD server, and create an ArgoCD Cluster. This is the ControllerConfig I used:
```yaml
apiVersion: pkg.crossplane.io/v1alpha1
kind: ControllerConfig
metadata:
  name: argocd-vault-config
spec:
  metadata:
    annotations:
      vault.hashicorp.com/agent-inject: "true"
      vault.hashicorp.com/role: crossplane
      vault.hashicorp.com/agent-inject-secret-authtoken: secret/crossplane/argocd
      vault.hashicorp.com/agent-inject-template-authtoken: |
        {{- with secret "secret/crossplane/argocd" -}}
          {{ .Data.data.authToken }}
        {{- end -}}
      vault.hashicorp.com/ca-cert: /vault/tls/ca.crt
      vault.hashicorp.com/tls-secret: vault
```

[contribution process]: https://git.io/fj2m9
