### PR TITLE
fix(cluster): Cluster fails to delete (#87)

### DIFF
--- a/pkg/controller/cluster/controller.go
+++ b/pkg/controller/cluster/controller.go
@@ -119,7 +119,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		}
 		return managed.ExternalObservation{}, errors.Wrap(err, errGetFailed)
 	}
-	if meta.WasDeleted(cr) && meta.GetExternalName(cr) == observedCluster.Name {
+	if meta.WasDeleted(cr) && meta.GetExternalName(cr) != observedCluster.Name {
 		// ArgoCD Cluster resource ignores the name field. This detects the deletion of the default cluster resource.
 		return managed.ExternalObservation{}, nil
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This just implements the recommendation by @stevendborrelli. Which fixes the issue of Cluster Objects not being deleted within ArgoCD, when the Cluster Resource is deleted.

Fixes #87 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.



### How has this code been tested
I ran `make build` and deployed the provider in a cluster with crossplane deployed.
A Cluster resource was created and I verified that it was created successfully using `argocd cluster list` and by viewing the status of `kubectl get clusters` then deleted the resource and verified that it was deleted in argocd using the same `argocd cluster list` command.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
