### PR TITLE
feat(scopedrepository): add support for project scoped repository

### DIFF
--- a/apis/repositories/v1alpha1/types.go
+++ b/apis/repositories/v1alpha1/types.go
@@ -53,6 +53,10 @@ type RepositoryParameters struct {
 	// type of the repo, maybe "git or "helm, "git" is assumed if empty or absent
 	// +optional
 	Type *string `json:"type,omitempty"`
+	// Project is a reference to the project with scoped repositories
+	// +optional
+	// only for git repos
+	Project *string `json:"project,omitempty"`
 	// only for Helm repos
 	// +optional
 	Name *string `json:"name,omitempty"`

--- a/apis/repositories/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/repositories/v1alpha1/zz_generated.deepcopy.go
@@ -162,6 +162,11 @@ func (in *RepositoryParameters) DeepCopyInto(out *RepositoryParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Project != nil {
+		in, out := &in.Project, &out.Project
+		*out = new(string)
+		**out = **in
+	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
 		*out = new(string)

--- a/examples/repositories/repository.yaml
+++ b/examples/repositories/repository.yaml
@@ -14,3 +14,20 @@ spec:
       key: token
   providerConfigRef:
     name: argocd-provider
+---
+apiVersion: repositories.argocd.crossplane.io/v1alpha1
+kind: Repository
+metadata:
+  name: example-scoped-project.git
+spec:
+  forProvider:
+    project: example-project # project scoped repository
+    repo: https://gitlab.com/example-group/example-project-scoped.git
+    type: git
+    username: example-user
+    passwordRef:
+      name: example-project.git
+      namespace: crossplane-system
+      key: token
+  providerConfigRef:
+    name: argocd-provider

--- a/package/crds/repositories.argocd.crossplane.io_repositories.yaml
+++ b/package/crds/repositories.argocd.crossplane.io_repositories.yaml
@@ -127,6 +127,10 @@ spec:
                     - name
                     - namespace
                     type: object
+                  project:
+                    description: Project is a reference to the project with scoped
+                      repositories only for git repos
+                    type: string
                   repo:
                     description: URL of the repo
                     type: string

--- a/pkg/controller/repositories/controller.go
+++ b/pkg/controller/repositories/controller.go
@@ -317,6 +317,9 @@ func generateCreateRepositoryOptions(p *v1alpha1.RepositoryParameters) *reposito
 	if p.Type != nil {
 		repo.Type = *p.Type
 	}
+	if p.Project != nil {
+		repo.Project = *p.Project
+	}
 	if p.Name != nil {
 		repo.Name = *p.Name
 	}
@@ -359,6 +362,9 @@ func generateUpdateRepositoryOptions(p *v1alpha1.RepositoryParameters) *reposito
 	}
 	if p.Type != nil {
 		repo.Type = *p.Type
+	}
+	if p.Project != nil {
+		repo.Project = *p.Project
 	}
 	if p.Name != nil {
 		repo.Name = *p.Name


### PR DESCRIPTION
### Description of your changes

This pull request introduces the capability for the argocd provider to support defining project-scoped repositories from the MR. Project-scoped repositories offer a self-service process for developers so that they can add a repository in a project on their own even after the initial creation of the project. [official-docs](https://argo-cd.readthedocs.io/en/stable/user-guide/projects/#project-scoped-repositories-and-clusters)

 
Fixes #126 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

The code has been tested using a local setup where an ArgoCD project was created using the argocd provider. I verified:

* The project key is correctly added to the secret that contains the repository information in argocd namespace after creating a Repository with project reference.
* The user defined in the project roles (rbac) can list the scoped repository from the UI. 
* There were no synchronization issues or delays.
