### PR TITLE
feat(projects): add sourceNamespaces field to ProjectParameters

### DIFF
--- a/apis/projects/v1alpha1/types.go
+++ b/apis/projects/v1alpha1/types.go
@@ -41,6 +41,9 @@ type ProjectParameters struct {
 	// Destinations contains list of destinations available for deployment
 	// +optional
 	Destinations []ApplicationDestination `json:"destinations,omitempty"`
+	// SourceNamespaces contains list of namespaces which are authorized in the project
+	// +optional
+	SourceNamespaces []string `json:"sourceNamespaces,omitempty"`
 	// Description contains optional project description
 	// +optional
 	Description *string `json:"description,omitempty"`

--- a/apis/projects/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/projects/v1alpha1/zz_generated.deepcopy.go
@@ -278,6 +278,11 @@ func (in *ProjectParameters) DeepCopyInto(out *ProjectParameters) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SourceNamespaces != nil {
+		in, out := &in.SourceNamespaces, &out.SourceNamespaces
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Description != nil {
 		in, out := &in.Description, &out.Description
 		*out = new(string)

--- a/examples/projects/project-with-source-namespaces.yaml
+++ b/examples/projects/project-with-source-namespaces.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: projects.argocd.crossplane.io/v1alpha1
+kind: Project
+metadata:
+  name: example-project
+spec:
+  forProvider:
+    sourceNamespaces:
+      - default
+    projectLabels:
+      argocd.crossplane.io/global-project: "true"
+  providerConfigRef:
+    name: argocd-provider

--- a/package/crds/projects.argocd.crossplane.io_projects.yaml
+++ b/package/crds/projects.argocd.crossplane.io_projects.yaml
@@ -334,6 +334,12 @@ spec:
                       - keyID
                       type: object
                     type: array
+                  sourceNamespaces:
+                    description: SourceNamespaces contains list of namespaces which
+                      are authorized in the project
+                    items:
+                      type: string
+                    type: array
                   sourceRepos:
                     description: SourceRepos contains list of repository URLs which
                       can be used for deployment

--- a/pkg/controller/projects/controller.go
+++ b/pkg/controller/projects/controller.go
@@ -434,6 +434,10 @@ func generateProjectSpec(p *v1alpha1.ProjectParameters) argocdv1alpha1.AppProjec
 		projSpec.ClusterResourceBlacklist = p.ClusterResourceBlacklist
 	}
 
+	if p.SourceNamespaces != nil {
+		projSpec.SourceNamespaces = p.SourceNamespaces
+	}
+
 	return projSpec
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds `sourceNamespaces` field to the MR so the project can be used in the Application in any Namespace context.

Fixes #198

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```bash
kubectl apply -f examples/projects/project-with-source-namespaces.yaml
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
