### PR TITLE
Add new flag '--reconciliation-timeout'

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -44,6 +44,7 @@ func main() {
 		enableManagementPolicies = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("false").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
 		maxReconcileRate         = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
 		pollInterval             = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for drift.").Default("1m").Duration()
+		reconciliationTimeout    = app.Flag("reconciliation-timeout", "The timeout duration for the reconciliation process. In case the deadline exceeds, necessary calls to report errors will still be made.").Default("1m").Duration()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -80,6 +81,7 @@ func main() {
 		Logger:                  log,
 		MaxConcurrentReconciles: *maxReconcileRate,
 		PollInterval:            *pollInterval,
+		ReconciliationTimeout:   *reconciliationTimeout,
 		GlobalRateLimiter:       ratelimiter.NewGlobal(*maxReconcileRate),
 		Features:                &feature.Flags{},
 	}

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -81,10 +81,8 @@ func main() {
 		Logger:                  log,
 		MaxConcurrentReconciles: *maxReconcileRate,
 		PollInterval:            *pollInterval,
-		// https://github.com/crossplane/crossplane-runtime/blob/main/pkg/controller/options.go there is no option yet
-		//ReconciliationTimeout:   *reconciliationTimeout,
-		GlobalRateLimiter: ratelimiter.NewGlobal(*maxReconcileRate),
-		Features:          &feature.Flags{},
+		GlobalRateLimiter:       ratelimiter.NewGlobal(*maxReconcileRate),
+		Features:                &feature.Flags{},
 	}
 
 	if *enableManagementPolicies {

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -81,9 +81,10 @@ func main() {
 		Logger:                  log,
 		MaxConcurrentReconciles: *maxReconcileRate,
 		PollInterval:            *pollInterval,
-		ReconciliationTimeout:   *reconciliationTimeout,
-		GlobalRateLimiter:       ratelimiter.NewGlobal(*maxReconcileRate),
-		Features:                &feature.Flags{},
+		// https://github.com/crossplane/crossplane-runtime/blob/main/pkg/controller/options.go there is no option yet
+		//ReconciliationTimeout:   *reconciliationTimeout,
+		GlobalRateLimiter: ratelimiter.NewGlobal(*maxReconcileRate),
+		Features:          &feature.Flags{},
 	}
 
 	if *enableManagementPolicies {
@@ -93,6 +94,6 @@ func main() {
 
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add argocd APIs to scheme")
-	kingpin.FatalIfError(controller.Setup(mgr, o), "Cannot setup argocd controllers")
+	kingpin.FatalIfError(controller.Setup(mgr, o, *reconciliationTimeout), "Cannot setup argocd controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/pkg/controller/applications/controller.go
+++ b/pkg/controller/applications/controller.go
@@ -64,6 +64,7 @@ func SetupApplication(mgr ctrl.Manager, o xpcontroller.Options) error {
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithTimeout(o.ReconciliationTimeout),
 	}
 
 	if o.Features.Enabled(features.EnableBetaManagementPolicies) {

--- a/pkg/controller/applications/controller.go
+++ b/pkg/controller/applications/controller.go
@@ -18,6 +18,7 @@ package applications
 
 import (
 	"context"
+	"time"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
@@ -52,7 +53,7 @@ const (
 )
 
 // SetupApplication adds a controller that reconciles applications.
-func SetupApplication(mgr ctrl.Manager, o xpcontroller.Options) error {
+func SetupApplication(mgr ctrl.Manager, o xpcontroller.Options, reconciliationTimeout time.Duration) error {
 	name := managed.ControllerName(v1alpha1.ApplicationKind)
 
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
@@ -64,7 +65,7 @@ func SetupApplication(mgr ctrl.Manager, o xpcontroller.Options) error {
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),
-		managed.WithTimeout(o.ReconciliationTimeout),
+		managed.WithTimeout(reconciliationTimeout),
 	}
 
 	if o.Features.Enabled(features.EnableBetaManagementPolicies) {

--- a/pkg/controller/argocd.go
+++ b/pkg/controller/argocd.go
@@ -19,6 +19,7 @@ package controller
 import (
 	xpcontroller "github.com/crossplane/crossplane-runtime/pkg/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"time"
 
 	"github.com/crossplane-contrib/provider-argocd/pkg/controller/applications"
 	"github.com/crossplane-contrib/provider-argocd/pkg/controller/applicationsets"
@@ -30,13 +31,17 @@ import (
 
 // Setup creates all argocd API controllers with the supplied logger and adds
 // them to the supplied manager.
-func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
+func Setup(mgr ctrl.Manager, o xpcontroller.Options, reconciliationTimeout time.Duration) error {
+	setupApplicationWithTimeout := func(mgr ctrl.Manager, o xpcontroller.Options) error {
+		return applications.SetupApplication(mgr, o, reconciliationTimeout)
+	}
+
 	for _, setup := range []func(ctrl.Manager, xpcontroller.Options) error{
 		config.Setup,
 		repositories.SetupRepository,
 		projects.SetupProject,
 		cluster.SetupCluster,
-		applications.SetupApplication,
+		setupApplicationWithTimeout,
 		applicationsets.SetupApplicationSet,
 	} {
 		if err := setup(mgr, o); err != nil {


### PR DESCRIPTION
### Description of your changes
This pull request introduces a new reconciliationTimeout flag to the Crossplane project. This feature allows users to specify a timeout duration for the reconciliation process, addressing the issue of indefinite waits during resource reconciliation. This enhancement ensures that the reconciliation function completes within a defined timeframe, improving reliability and efficiency in resource management. The timeout is cumulative for all calls within a single reconciliation cycle, allowing necessary operations such as error reporting and status updates to be completed before the timeout is enforced.

Fixes #217

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I built the provider and deployed it locally using the following configuration:
```
apiVersion: pkg.crossplane.io/v1beta1
kind: DeploymentRuntimeConfig
metadata:
  name: crossplane-cloudplatform-argocd
spec:
  deploymentTemplate:
    spec:
      selector: {}
      template:
        spec:
          containers:
          - name: package-runtime
            args:
            - --reconciliation-timeout=3m
            - --debug
```

I tested the feature with an application using the Helmfile plugin, where Helmfile rendering typically takes more than 1 minute. With the default reconciliation timeout set to 60 seconds, longer rendering processes would fail. By setting the reconciliation timeout to more than 60 seconds, I was able to successfully create an application with manifest generation taking over a minute, without encountering any errors.

Helmfile example:
```
/your-helmfile-directory
  ├── delay.sh
  └── helmfile.yaml
```

```
#!/bin/bash
echo "Starting delay..."
for ((i=60; i>0; i--)); do
  echo "$i seconds left"
  sleep 1
done
echo "Delay completed."
```

```
repositories:
  - name: bitnami
    url: https://charts.bitnami.com/bitnami

releases:
  - name: my-nginx-release
    namespace: default
    chart: bitnami/nginx
    version: 15.4.0  # Specify a stable version
    hooks:
      - events: ["prepare"]
        command: "./delay.sh"
        showlogs: true
```
