### PR TITLE
fix(application): Increase reconciliation timeout to 5 Minutes

### DIFF
--- a/pkg/controller/applications/controller.go
+++ b/pkg/controller/applications/controller.go
@@ -18,6 +18,7 @@ package applications
 
 import (
 	"context"
+	"time"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient"
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
@@ -64,6 +65,7 @@ func SetupApplication(mgr ctrl.Manager, o xpcontroller.Options) error {
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),
+		managed.WithTimeout(5 * time.Minute),
 	}
 
 	if o.Features.Enabled(features.EnableBetaManagementPolicies) {


### PR DESCRIPTION
### Description of your changes
This pull request modifies the timeout for the application controller in the Crossplane project by hardcoding it to 5 minutes. The previous implementation [#218](https://github.com/crossplane-contrib/provider-argocd/pull/218) suggested using a configurable reconciliationTimeout flag, which implied it would be applied to all controllers. However, this change specifically targets only the application controller.
The decision to hardcode the timeout to 5 minutes is based on the observation that it is more straightforward to increase the timeout for applications directly, rather than introducing a configuration option. This adjustment aims to enhance the reliability and efficiency of application management by ensuring the process completes within a reasonable timeframe.

Fixes #217

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I tested the feature with an application using the Helmfile plugin, where Helmfile rendering typically takes more than 1 minute. With the default reconciliation timeout set to 60 seconds, longer rendering processes would fail. By setting the reconciliation timeout to more than 60 seconds, I was able to successfully create an application with manifest generation taking over a minute, without encountering any errors.

Helmfile example:
```
/your-helmfile-directory
  ├── delay.sh
  └── helmfile.yaml
```

```
#!/bin/bash
echo "Starting delay..."
for ((i=60; i>0; i--)); do
  echo "$i seconds left"
  sleep 1
done
echo "Delay completed."
```

```
repositories:
  - name: bitnami
    url: https://charts.bitnami.com/bitnami

releases:
  - name: my-nginx-release
    namespace: default
    chart: bitnami/nginx
    version: 15.4.0  # Specify a stable version
    hooks:
      - events: ["prepare"]
        command: "./delay.sh"
        showlogs: true
```
