### PR TITLE
fix: Make provider-argocd Application controller report accurate Ready state

### DIFF
--- a/pkg/controller/applications/comp_test.go
+++ b/pkg/controller/applications/comp_test.go
@@ -1,0 +1,167 @@
+package applications
+
+import (
+	"testing"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/crossplane-contrib/provider-argocd/apis/applications/v1alpha1"
+)
+
+func TestGetApplicationCondition(t *testing.T) {
+	type args struct {
+		status *v1alpha1.ArgoApplicationStatus
+	}
+
+	type want struct {
+		condition xpv1.Condition
+	}
+
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"NilStatus": {
+			args: args{
+				status: nil,
+			},
+			want: want{
+				condition: xpv1.Unavailable(),
+			},
+		},
+		"NoOperationState": {
+			args: args{
+				status: &v1alpha1.ArgoApplicationStatus{
+					Health: v1alpha1.HealthStatus{
+						Status: "Healthy",
+					},
+					Sync: v1alpha1.SyncStatus{
+						Status: "Synced",
+					},
+				},
+			},
+			want: want{
+				condition: xpv1.Available(),
+			},
+		},
+		"ReadyWithSyncedStatus": {
+			args: args{
+				status: &v1alpha1.ArgoApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						Phase: "Succeeded",
+					},
+					Health: v1alpha1.HealthStatus{
+						Status: "Healthy",
+					},
+					Sync: v1alpha1.SyncStatus{
+						Status: "Synced",
+					},
+				},
+			},
+			want: want{
+				condition: xpv1.Available(),
+			},
+		},
+		"ReadyWithOutOfSyncStatus": {
+			args: args{
+				status: &v1alpha1.ArgoApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						Phase: "Succeeded",
+					},
+					Health: v1alpha1.HealthStatus{
+						Status: "Healthy",
+					},
+					Sync: v1alpha1.SyncStatus{
+						Status: "OutOfSync",
+					},
+				},
+			},
+			want: want{
+				condition: xpv1.Available(),
+			},
+		},
+		"NotReadyDueToHealth": {
+			args: args{
+				status: &v1alpha1.ArgoApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						Phase: "Succeeded",
+					},
+					Health: v1alpha1.HealthStatus{
+						Status: "Degraded",
+					},
+					Sync: v1alpha1.SyncStatus{
+						Status: "Synced",
+					},
+				},
+			},
+			want: want{
+				condition: xpv1.Unavailable(),
+			},
+		},
+		"NotReadyDueToOperation": {
+			args: args{
+				status: &v1alpha1.ArgoApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						Phase: "Failed",
+					},
+					Health: v1alpha1.HealthStatus{
+						Status: "Healthy",
+					},
+					Sync: v1alpha1.SyncStatus{
+						Status: "Synced",
+					},
+				},
+			},
+			want: want{
+				condition: xpv1.Unavailable(),
+			},
+		},
+		"NotReadyDueToEmptyOperation": {
+			args: args{
+				status: &v1alpha1.ArgoApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						Phase: "",
+					},
+					Health: v1alpha1.HealthStatus{
+						Status: "Healthy",
+					},
+					Sync: v1alpha1.SyncStatus{
+						Status: "Synced",
+					},
+				},
+			},
+			want: want{
+				condition: xpv1.Unavailable(),
+			},
+		},
+		"NotReadyWithMultipleIssues": {
+			args: args{
+				status: &v1alpha1.ArgoApplicationStatus{
+					OperationState: &v1alpha1.OperationState{
+						Phase: "Failed",
+					},
+					Health: v1alpha1.HealthStatus{
+						Status: "Degraded",
+					},
+					Sync: v1alpha1.SyncStatus{
+						Status: "OutOfSync",
+					},
+				},
+			},
+			want: want{
+				condition: xpv1.Unavailable(),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := getApplicationCondition(tc.args.status)
+			if diff := cmp.Diff(tc.want.condition, got, cmpopts.IgnoreFields(xpv1.Condition{}, "LastTransitionTime")); diff != "" {
+				t.Errorf("getApplicationCondition(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/applications/controller.go
+++ b/pkg/controller/applications/controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/argoproj/argo-cd/v2/pkg/apiclient/application"
 	argocdv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/argoproj/argo-cd/v2/util/io"
-	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	xpcontroller "github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
@@ -145,7 +144,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	lateInitialize(&cr.Spec.ForProvider, app)
 
 	cr.Status.AtProvider = generateApplicationObservation(app)
-	cr.Status.SetConditions(xpv1.Available())
+	cr.Status.SetConditions(getApplicationCondition(&cr.Status.AtProvider))
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,

--- a/pkg/controller/applications/controller_test.go
+++ b/pkg/controller/applications/controller_test.go
@@ -144,7 +144,14 @@ func TestObserve(t *testing.T) {
 										},
 									},
 								},
-								Status: argocdv1alpha1.ApplicationStatus{},
+								Status: argocdv1alpha1.ApplicationStatus{
+									Health: argocdv1alpha1.HealthStatus{
+										Status: "Healthy",
+									},
+									Sync: argocdv1alpha1.SyncStatus{
+										Status: "Synced",
+									},
+								},
 							}},
 						}, nil)
 				}),
@@ -192,7 +199,33 @@ func TestObserve(t *testing.T) {
 						Finalizers:  testApplicationFinalizers,
 					}),
 					withConditions(xpv1.Available()),
-					withObservation(initializedArgoAppStatus()),
+					withObservation(v1alpha1.ArgoApplicationStatus{
+						Resources: nil,
+						Sync: v1alpha1.SyncStatus{
+							Status:   "Synced",
+							Revision: &emptyString,
+							ComparedTo: v1alpha1.ComparedTo{
+								Source: v1alpha1.ApplicationSource{
+									Path:           &emptyString,
+									TargetRevision: &emptyString,
+									Chart:          &emptyString,
+									Ref:            &emptyString,
+								},
+								Destination: v1alpha1.ApplicationDestination{
+									Server:    &emptyString,
+									Namespace: &emptyString,
+									Name:      &emptyString,
+								},
+							},
+						},
+						Health: v1alpha1.HealthStatus{
+							Status:  "Healthy",
+							Message: &emptyString,
+						},
+						SourceType:           "",
+						Summary:              v1alpha1.ApplicationSummary{},
+						ResourceHealthSource: "",
+					}),
 				),
 				result: managed.ExternalObservation{
 					ResourceExists:          true,
@@ -232,7 +265,14 @@ func TestObserve(t *testing.T) {
 										Namespace: testDestinationNamespace,
 									},
 								},
-								Status: argocdv1alpha1.ApplicationStatus{},
+								Status: argocdv1alpha1.ApplicationStatus{
+									Health: argocdv1alpha1.HealthStatus{
+										Status: "Missing",
+									},
+									Sync: argocdv1alpha1.SyncStatus{
+										Status: "OutOfSync",
+									},
+								},
 							}},
 						}, nil)
 				}),
@@ -279,7 +319,7 @@ func TestObserve(t *testing.T) {
 						Annotations: testApplicationAnnotations,
 						Finalizers:  testApplicationFinalizers,
 					}),
-					withConditions(xpv1.Available()),
+					withConditions(xpv1.Unavailable()),
 					withObservation(initializedArgoAppStatus()),
 				),
 				result: managed.ExternalObservation{
@@ -382,6 +422,7 @@ func initializedArgoAppStatus() v1alpha1.ArgoApplicationStatus {
 	return v1alpha1.ArgoApplicationStatus{
 		Resources: nil,
 		Sync: v1alpha1.SyncStatus{
+			Status:   "OutOfSync",
 			Revision: &emptyString,
 			ComparedTo: v1alpha1.ComparedTo{
 				Source: v1alpha1.ApplicationSource{
@@ -398,6 +439,7 @@ func initializedArgoAppStatus() v1alpha1.ArgoApplicationStatus {
 			},
 		},
 		Health: v1alpha1.HealthStatus{
+			Status:  "Missing",
 			Message: &emptyString,
 		},
 		SourceType:           "",


### PR DESCRIPTION
### Description of your changes

Fixes #239 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.  # this doesn't exist?

### How has this code been tested
* Unit tests added for new ready check function
* Code functionally validated locally:

Resource added but not synced
```
$ kubectl get application.applications.argocd.crossplane.io/example-application -o yaml
apiVersion: applications.argocd.crossplane.io/v1alpha1
kind: Application
metadata:
  annotations:
    crossplane.io/external-create-pending: "2025-02-13T00:35:15-05:00"
    crossplane.io/external-create-succeeded: "2025-02-13T00:35:15-05:00"
    crossplane.io/external-name: example-application
  creationTimestamp: "2025-02-13T05:35:15Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 1
  name: example-application
  resourceVersion: "20927991"
  uid: ee652706-032a-46aa-af12-239f64cc252f
spec:
  deletionPolicy: Delete
  forProvider:
    destination:
      namespace: default
      server: https://kubernetes.default.svc
    project: default
    source:
      path: charts/podinfo
      repoURL: https://github.com/stefanprodan/podinfo/
      targetRevision: HEAD
  managementPolicies:
  - '*'
  providerConfigRef:
    name: argocd-provider
status:
  atProvider:
    health:
      message: ""
      status: Missing
    resources:
    - group: ""
      health:
        message: ""
        status: Missing
      hook: false
      kind: Service
      name: example-application-podinfo
      namespace: default
      requiresPruning: false
      status: OutOfSync
      syncWave: 0
      version: v1
    - group: apps
      health:
        message: ""
        status: Missing
      hook: false
      kind: Deployment
      name: example-application-podinfo
      namespace: default
      requiresPruning: false
      status: OutOfSync
      syncWave: 0
      version: v1
    sourceType: Helm
    summary: {}
    sync:
      comparedTo:
        destination:
          name: ""
          namespace: default
          server: https://kubernetes.default.svc
        source:
          chart: ""
          path: charts/podinfo
          ref: ""
          repoURL: https://github.com/stefanprodan/podinfo/
          targetRevision: HEAD
      revision: b99bf8c252d47db1cccfb6546aec650679645e61
      status: OutOfSync
  conditions:
  - lastTransitionTime: "2025-02-13T05:35:16Z"
    message: 'Health status: Missing; Sync status: OutOfSync'
    reason: Unavailable
    status: "False"
    type: Ready
  - lastTransitionTime: "2025-02-13T05:35:15Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
```

After resource synced:
```
apiVersion: applications.argocd.crossplane.io/v1alpha1
kind: Application
metadata:
  annotations:
    crossplane.io/external-create-pending: "2025-02-13T00:35:15-05:00"
    crossplane.io/external-create-succeeded: "2025-02-13T00:35:15-05:00"
    crossplane.io/external-name: example-application
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"applications.argocd.crossplane.io/v1alpha1","kind":"Application","metadata":{"annotations":{},"name":"example-application"},"spec":{"forProvider":{"destination":{"namespace":"default","server":"https://kubernetes.default.svc"},"project":"default","source":{"path":"charts/podinfo","repoURL":"https://github.com/stefanprodan/podinfo/","targetRevision":"HEAD"}},"providerConfigRef":{"name":"argocd-provider"}}}
  creationTimestamp: "2025-02-13T05:35:15Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 1
  name: example-application
  resourceVersion: "20928324"
  uid: ee652706-032a-46aa-af12-239f64cc252f
spec:
  deletionPolicy: Delete
  forProvider:
    destination:
      namespace: default
      server: https://kubernetes.default.svc
    project: default
    source:
      path: charts/podinfo
      repoURL: https://github.com/stefanprodan/podinfo/
      targetRevision: HEAD
  managementPolicies:
  - '*'
  providerConfigRef:
    name: argocd-provider
status:
  atProvider:
    health:
      message: ""
      status: Healthy
    history:
    - id: 0
      revision: b99bf8c252d47db1cccfb6546aec650679645e61
      source:
        chart: ""
        path: charts/podinfo
        ref: ""
        repoURL: https://github.com/stefanprodan/podinfo/
        targetRevision: HEAD
    operationState:
      message: successfully synced (all tasks run)
      operation:
        initiatedBy:
          automated: false
          username: admin
        retry:
          limit: 0
        sync:
          dryRun: false
          prune: false
          revision: b99bf8c252d47db1cccfb6546aec650679645e61
          syncStrategy:
            hook:
              force: false
      phase: Succeeded
      retryCount: 0
      syncResult:
        resources:
        - group: ""
          hookPhase: Running
          hookType: ""
          kind: Service
          message: service/example-application-podinfo created
          name: example-application-podinfo
          namespace: default
          status: Synced
          syncPhase: Sync
          version: v1
        - group: apps
          hookPhase: Running
          hookType: ""
          kind: Deployment
          message: deployment.apps/example-application-podinfo created
          name: example-application-podinfo
          namespace: default
          status: Synced
          syncPhase: Sync
          version: v1
        revision: b99bf8c252d47db1cccfb6546aec650679645e61
        source:
          chart: ""
          path: charts/podinfo
          ref: ""
          repoURL: https://github.com/stefanprodan/podinfo/
          targetRevision: HEAD
    resources:
    - group: ""
      health:
        message: ""
        status: Healthy
      hook: false
      kind: Service
      name: example-application-podinfo
      namespace: default
      requiresPruning: false
      status: Synced
      syncWave: 0
      version: v1
    - group: apps
      health:
        message: ""
        status: Healthy
      hook: false
      kind: Deployment
      name: example-application-podinfo
      namespace: default
      requiresPruning: false
      status: Synced
      syncWave: 0
      version: v1
    sourceType: Helm
    summary:
      images:
      - ghcr.io/stefanprodan/podinfo:6.7.1
    sync:
      comparedTo:
        destination:
          name: ""
          namespace: default
          server: https://kubernetes.default.svc
        source:
          chart: ""
          path: charts/podinfo
          ref: ""
          repoURL: https://github.com/stefanprodan/podinfo/
          targetRevision: HEAD
      revision: b99bf8c252d47db1cccfb6546aec650679645e61
      status: Synced
  conditions:
  - lastTransitionTime: "2025-02-13T05:36:16Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-02-13T05:35:15Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
```
[contribution process]: https://git.io/fj2m9
