### PR TITLE
fix(token): Use correct controller name

### DIFF
--- a/pkg/controller/tokens/controller.go
+++ b/pkg/controller/tokens/controller.go
@@ -39,7 +39,7 @@ const (
 
 // SetupToken adds a controller that reconciles tokens.
 func SetupToken(mgr ctrl.Manager, o xpcontroller.Options) error {
-	name := managed.ControllerName(v1alpha1.ProjectKind)
+	name := managed.ControllerName(v1alpha1.TokenKind)
 
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnectDisconnecter(&connector{kube: mgr.GetClient(), newArgocdClientFn: projects.NewProjectServiceClient}), //nolint:staticcheck


### PR DESCRIPTION


### Description of your changes

Sets the proper controller name for tokens. 

Fixes #257 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make run` starts controller up successfully. It failed beforehand.