### PR TITLE
feat: Add custom project name option

### DIFF
--- a/apis/projects/v1alpha1/types.go
+++ b/apis/projects/v1alpha1/types.go
@@ -23,6 +23,9 @@ import (
 
 // ProjectParameters define the desired state of an ArgoCD Git Project
 type ProjectParameters struct {
+	// Name is the name of the project
+	// +optional
+	Name string `json:"name,omitempty"`
 	// SourceRepos contains list of repository URLs which can be used for deployment
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-argocd/apis/repositories/v1alpha1.Repository
 	// +crossplane:generate:reference:refFieldName=SourceReposRefs

--- a/examples/projects/project.yaml
+++ b/examples/projects/project.yaml
@@ -5,6 +5,8 @@ metadata:
   name: example-project
 spec:
   forProvider:
+    name: example-project-name
+    description: Example Project with specified name
     projectLabels:
       argocd.crossplane.io/global-project: "true"
   providerConfigRef:

--- a/package/crds/projects.argocd.crossplane.io_projects.yaml
+++ b/package/crds/projects.argocd.crossplane.io_projects.yaml
@@ -207,6 +207,9 @@ spec:
                           type: object
                       type: object
                     type: array
+                  name:
+                    description: Name is the name of the project
+                    type: string
                   namespaceResourceBlacklist:
                     description: NamespaceResourceBlacklist contains list of blacklisted
                       namespace level resources

--- a/pkg/controller/projects/controller.go
+++ b/pkg/controller/projects/controller.go
@@ -337,10 +337,15 @@ func generateProjectObservation(r *argocdv1alpha1.AppProject) v1alpha1.ProjectOb
 func generateCreateProjectOptions(p *v1alpha1.Project) *project.ProjectCreateRequest {
 	projSpec := generateProjectSpec(&p.Spec.ForProvider)
 
+	projName := p.Name
+	if specName := p.Spec.ForProvider.Name; specName != "" {
+		projName = specName
+	}
+
 	projectCreateRequest := &project.ProjectCreateRequest{
 		Project: &argocdv1alpha1.AppProject{
 			Spec:       projSpec,
-			ObjectMeta: metav1.ObjectMeta{Name: p.Name, Labels: p.Spec.ForProvider.ProjectLabels},
+			ObjectMeta: metav1.ObjectMeta{Name: projName, Labels: p.Spec.ForProvider.ProjectLabels},
 		},
 		Upsert: false,
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes #325 by introducing a new project `name` field in project API, which is set optional and modifies the naming logic so that the metadata name is used as a fallback if project name not set. 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

After running the provider successfully, we can run in another terminal `kubectl apply -f examples/projects/project.yaml` to create a new project. The reconciliation of project works as before, successfully updating and deleting. To see the results, we can authenticate as described in [hack/local-argocd-setup.sh](https://github.com/crossplane-contrib/provider-argocd/blob/main/hack/local-argocd-setup.sh). The following command lists the projects successfully:

```bash
> argocd proj list

NAME                  DESCRIPTION                          DESTINATIONS  SOURCES  CLUSTER-RESOURCE-WHITELIST  NAMESPACE-RESOURCE-BLACKLIST  SIGNATURE-KEYS  ORPHANED-RESOURCES  DESTINATION-SERVICE-ACCOUNTS
default                                                    *,*           *        */*                         <none>                        <none>          disabled            <none>
example-project-name  Example Project with specified name  <none>        <none>   <none>                      <none>                        <none>          disabled            <none>
```

[contribution process]: https://git.io/fj2m9
