### PR TITLE
fix(repositories): Support project scoping for Observe, Delete in Repository resources

### DIFF
--- a/pkg/controller/repositories/controller.go
+++ b/pkg/controller/repositories/controller.go
@@ -131,6 +131,10 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		Repo: meta.GetExternalName(cr),
 	}
 
+	if cr.Spec.ForProvider.Project != nil {
+		repoQuery.AppProject = *cr.Spec.ForProvider.Project
+	}
+
 	observedRepository, err := e.client.Get(ctx, &repoQuery)
 
 	if err != nil && repositories.IsErrorPermissionDenied(err) || repositories.IsErrorRepositoryNotFound(err) {
@@ -276,6 +280,10 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 	repoQuery := repository.RepoQuery{
 		Repo: meta.GetExternalName(cr),
+	}
+
+	if cr.Spec.ForProvider.Project != nil {
+		repoQuery.AppProject = *cr.Spec.ForProvider.Project
 	}
 
 	_, err := e.client.DeleteRepository(ctx, &repoQuery)

--- a/pkg/controller/repositories/controller_test.go
+++ b/pkg/controller/repositories/controller_test.go
@@ -255,6 +255,112 @@ func TestObserve(t *testing.T) {
 				err: nil,
 			},
 		},
+		"SuccessfulWithAppProject": {
+			args: args{
+				client: withMockClient(t, func(mcs *mockclient.MockRepositoryServiceClient) {
+					mcs.EXPECT().Get(
+						context.Background(),
+						&argocdRepository.RepoQuery{
+							Repo:       testRepositoryExternalName,
+							AppProject: "test-project",
+						},
+					).Return(
+						&argocdv1alpha1.Repository{
+							Repo:    testRepo,
+							Name:    testRepositoryExternalName,
+							Project: "test-project",
+						}, nil)
+				}),
+				cr: Repository(
+					withExternalName(testRepositoryExternalName),
+					withSpec(v1alpha1.RepositoryParameters{
+						Name:           ptr.To(testRepositoryExternalName),
+						Repo:           testRepo,
+						Project:        ptr.To("test-project"),
+						Insecure:       &testInsecure,
+						EnableLFS:      &testEnableLFS,
+						InheritedCreds: &testInheritedCreds,
+						EnableOCI:      &testEnableOCI,
+					}),
+				),
+			},
+			want: want{
+				cr: Repository(
+					withExternalName(testRepositoryExternalName),
+					withSpec(v1alpha1.RepositoryParameters{
+						Name:           ptr.To(testRepositoryExternalName),
+						Repo:           testRepo,
+						Project:        ptr.To("test-project"),
+						Insecure:       &testInsecure,
+						EnableLFS:      &testEnableLFS,
+						InheritedCreds: &testInheritedCreds,
+						EnableOCI:      &testEnableOCI,
+					}),
+					withConditions(xpv1.Available()),
+					withObservation(v1alpha1.RepositoryObservation{
+						ConnectionState: v1alpha1.ConnectionState{},
+					}),
+				),
+				result: managed.ExternalObservation{
+					ResourceExists:          true,
+					ResourceUpToDate:        true,
+					ResourceLateInitialized: false,
+				},
+				err: nil,
+			},
+		},
+		"SuccessfulWithoutAppProject": {
+			args: args{
+				client: withMockClient(t, func(mcs *mockclient.MockRepositoryServiceClient) {
+					mcs.EXPECT().Get(
+						context.Background(),
+						&argocdRepository.RepoQuery{
+							Repo: testRepositoryExternalName,
+						},
+					).Return(
+						&argocdv1alpha1.Repository{
+							Repo: testRepo,
+							Name: testRepositoryExternalName,
+						}, nil)
+				}),
+				cr: Repository(
+					withExternalName(testRepositoryExternalName),
+					withSpec(v1alpha1.RepositoryParameters{
+						Name:           ptr.To(testRepositoryExternalName),
+						Repo:           testRepo,
+						Project:        nil, // Explicitly nil
+						Insecure:       &testInsecure,
+						EnableLFS:      &testEnableLFS,
+						InheritedCreds: &testInheritedCreds,
+						EnableOCI:      &testEnableOCI,
+					}),
+				),
+			},
+			want: want{
+				cr: Repository(
+					withExternalName(testRepositoryExternalName),
+					withSpec(v1alpha1.RepositoryParameters{
+						Name:           ptr.To(testRepositoryExternalName),
+						Repo:           testRepo,
+						Project:        nil,
+						Insecure:       &testInsecure,
+						EnableLFS:      &testEnableLFS,
+						InheritedCreds: &testInheritedCreds,
+						EnableOCI:      &testEnableOCI,
+					}),
+					withConditions(xpv1.Available()),
+					withObservation(v1alpha1.RepositoryObservation{
+						ConnectionState: v1alpha1.ConnectionState{},
+					}),
+				),
+				result: managed.ExternalObservation{
+					ResourceExists:          true,
+					ResourceUpToDate:        true,
+					ResourceLateInitialized: false,
+				},
+				err: nil,
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -549,6 +655,67 @@ func TestDelete(t *testing.T) {
 					}),
 				),
 				err: errors.Wrap(errBoom, errDeleteFailed),
+			},
+		},
+		"SuccessfulWithAppProject": {
+			args: args{
+				client: withMockClient(t, func(mcs *mockclient.MockRepositoryServiceClient) {
+					mcs.EXPECT().DeleteRepository(
+						context.Background(),
+						&argocdRepository.RepoQuery{
+							Repo:       testRepositoryExternalName,
+							AppProject: "test-project",
+						},
+					).Return(
+						&argocdRepository.RepoResponse{}, nil)
+				}),
+				cr: Repository(
+					withExternalName(testRepositoryExternalName),
+					withSpec(v1alpha1.RepositoryParameters{
+						Repo:    testRepositoryExternalName,
+						Project: ptr.To("test-project"),
+					}),
+				),
+			},
+			want: want{
+				cr: Repository(
+					withExternalName(testRepositoryExternalName),
+					withSpec(v1alpha1.RepositoryParameters{
+						Repo:    testRepositoryExternalName,
+						Project: ptr.To("test-project"),
+					}),
+				),
+				err: nil,
+			},
+		},
+		"SuccessfulWithoutAppProject": {
+			args: args{
+				client: withMockClient(t, func(mcs *mockclient.MockRepositoryServiceClient) {
+					mcs.EXPECT().DeleteRepository(
+						context.Background(),
+						&argocdRepository.RepoQuery{
+							Repo: testRepositoryExternalName,
+						},
+					).Return(
+						&argocdRepository.RepoResponse{}, nil)
+				}),
+				cr: Repository(
+					withExternalName(testRepositoryExternalName),
+					withSpec(v1alpha1.RepositoryParameters{
+						Repo:    testRepositoryExternalName,
+						Project: nil, // Explicitly nil
+					}),
+				),
+			},
+			want: want{
+				cr: Repository(
+					withExternalName(testRepositoryExternalName),
+					withSpec(v1alpha1.RepositoryParameters{
+						Repo:    testRepositoryExternalName,
+						Project: nil,
+					}),
+				),
+				err: nil,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

For Repositories, there's a wierd behaviour that when you pass a Project in the XRD, the Argo repository gets created, but it goes into an unhealthy state right after that. This happens because I think there's a bug in the Repository controller code. In the Observe function, we don't pass the project to the `RepoQuery` explicitly, and therefore it fails with an obvious error `
observe failed: rpc error: code = Unknown desc = repository not found for url "https://github.com/my-org/hello-world.git" and project ""`. I've added the param and added a test case to validate.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane-contrib/provider-argocd/issues/245

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
