### PR TITLE
feat(project): Use external annotation name as project name

### DIFF
--- a/examples/projects/project.yaml
+++ b/examples/projects/project.yaml
@@ -3,6 +3,8 @@ apiVersion: projects.argocd.crossplane.io/v1alpha1
 kind: Project
 metadata:
   name: example-project
+  annotations:
+    crossplane.io/external-name: example-project-name
 spec:
   forProvider:
     projectLabels:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes #325 by using the external annotation name field without having to modify project API, the naming logic is set so that the metadata name is used as a fallback if the annotated name is empty.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Currently, the issue described in #340 causes failure, thus we're unable to test it. If solved, the running steps would be as follows:

1. Run the provider successfully
2. Run in another terminal `kubectl apply -f examples/projects/project.yaml` to create a new project
3. Authenticate as described in [hack/local-argocd-setup.sh](https://github.com/crossplane-contrib/provider-argocd/blob/main/hack/local-argocd-setup.sh)
4. Run `argocd proj list` to see the results

[contribution process]: https://git.io/fj2m9
