### PR TITLE
fix: return errors instead of panicking when argocd client fails

### DIFF
--- a/pkg/clients/cluster/argocd.go
+++ b/pkg/clients/cluster/argocd.go
@@ -35,16 +35,17 @@ import (
 	"github.com/crossplane-contrib/provider-argocd/apis/cluster/v1alpha1"
 )
 
-// NewClient creates new argocd Client with provided argocd Configurations/Credentials.
-func NewClient(opts *argocd.ClientOptions) *argocd.Client {
-	var cl argocd.Client
-	var err error
-	cl, err = argocd.NewClient(opts)
-
+// NewClient creates new argocd Client with provided argocd
+// Configurations/Credentials. Any error from constructing the underlying
+// argo-cd client (for example, a transient DNS failure while resolving the
+// server address) is returned to the caller so the reconciler can retry with
+// backoff instead of panicking and crashing the controller process.
+func NewClient(opts *argocd.ClientOptions) (*argocd.Client, error) {
+	cl, err := argocd.NewClient(opts)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return &cl
+	return &cl, nil
 }
 
 // GetConfig constructs a Config that can be used to authenticate to argocd

--- a/pkg/clients/interface/applications/client.go
+++ b/pkg/clients/interface/applications/client.go
@@ -33,10 +33,20 @@ type ServiceClient interface {
 	Delete(ctx context.Context, in *application.ApplicationDeleteRequest, opts ...grpc.CallOption) (*application.ApplicationResponse, error)
 }
 
-// NewApplicationServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewApplicationServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, ServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewApplicationClientOrDie()
-	return conn, repoIf
+// NewApplicationServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the application gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewApplicationServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, ServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewApplicationClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorApplicationNotFound helper function to test for errorNotFound error.

--- a/pkg/clients/interface/applicationsets/client.go
+++ b/pkg/clients/interface/applicationsets/client.go
@@ -24,10 +24,20 @@ type ServiceClient interface {
 	Delete(ctx context.Context, in *applicationset.ApplicationSetDeleteRequest, opts ...grpc.CallOption) (*applicationset.ApplicationSetResponse, error)
 }
 
-// NewApplicationSetServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewApplicationSetServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, ServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewApplicationSetClientOrDie()
-	return conn, repoIf
+// NewApplicationSetServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the application-set gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewApplicationSetServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, ServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewApplicationSetClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsNotFound returns true if the error code is NotFound

--- a/pkg/clients/interface/cluster/client.go
+++ b/pkg/clients/interface/cluster/client.go
@@ -28,10 +28,20 @@ type ServiceClient interface {
 	Delete(ctx context.Context, in *cluster.ClusterQuery, opts ...grpc.CallOption) (*cluster.ClusterResponse, error)
 }
 
-// NewClusterServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewClusterServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, cluster.ClusterServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewClusterClientOrDie()
-	return conn, repoIf
+// NewClusterServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the cluster gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewClusterServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, cluster.ClusterServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewClusterClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorClusterNotFound helper function to test for errorClusterNotFound error.

--- a/pkg/clients/interface/clusters/client.go
+++ b/pkg/clients/interface/clusters/client.go
@@ -28,10 +28,20 @@ type ServiceClient interface {
 	Delete(ctx context.Context, in *cluster.ClusterQuery, opts ...grpc.CallOption) (*cluster.ClusterResponse, error)
 }
 
-// NewClusterServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewClusterServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, cluster.ClusterServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewClusterClientOrDie()
-	return conn, repoIf
+// NewClusterServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the cluster gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewClusterServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, cluster.ClusterServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewClusterClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorClusterNotFound helper function to test for errorClusterNotFound error.

--- a/pkg/clients/interface/projects/client.go
+++ b/pkg/clients/interface/projects/client.go
@@ -31,10 +31,20 @@ type ProjectServiceClient interface {
 	DeleteToken(ctx context.Context, in *project.ProjectTokenDeleteRequest, opts ...grpc.CallOption) (*project.EmptyResponse, error)
 }
 
-// NewProjectServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewProjectServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewProjectClientOrDie()
-	return conn, repoIf
+// NewProjectServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the project gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewProjectServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewProjectClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorProjectNotFound helper function to test for errorProjectNotFound error.

--- a/pkg/clients/interface/repositories/client.go
+++ b/pkg/clients/interface/repositories/client.go
@@ -30,10 +30,20 @@ type RepositoryServiceClient interface {
 	DeleteRepository(ctx context.Context, in *repository.RepoQuery, opts ...grpc.CallOption) (*repository.RepoResponse, error)
 }
 
-// NewRepositoryServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewRepositoryServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewRepoClientOrDie()
-	return conn, repoIf
+// NewRepositoryServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the repository gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewRepositoryServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewRepoClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorRepositoryNotFound helper function to test for errorRepositoryNotFound error.

--- a/pkg/controller/cluster/applications/controller.go
+++ b/pkg/controller/cluster/applications/controller.go
@@ -90,7 +90,7 @@ func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec man
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, applications.ServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, applications.ServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -102,14 +102,17 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	return NewExternal(func() (io.Closer, applications.ServiceClient) {
+	return NewExternal(func() (io.Closer, applications.ServiceClient, error) {
 		return c.newArgocdClientFn(cfg)
-	}), nil
+	})
 }
 
-func NewExternal(newArgocdClientFn func() (io.Closer, applications.ServiceClient)) managed.ExternalClient {
-	conn, argocdClient := newArgocdClientFn()
-	return &external{client: argocdClient, conn: conn}
+func NewExternal(newArgocdClientFn func() (io.Closer, applications.ServiceClient, error)) (managed.ExternalClient, error) {
+	conn, argocdClient, err := newArgocdClientFn()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
+	return &external{client: argocdClient, conn: conn}, nil
 }
 
 type external struct {

--- a/pkg/controller/cluster/applicationsets/controller.go
+++ b/pkg/controller/cluster/applicationsets/controller.go
@@ -104,14 +104,17 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, err
 	}
 
-	return NewExternal(func() (io.Closer, appsets.ServiceClient) {
+	return NewExternal(func() (io.Closer, appsets.ServiceClient, error) {
 		return appsets.NewApplicationSetServiceClient(cfg)
-	}), nil
+	})
 }
 
-func NewExternal(newArgocdClientFn func() (io.Closer, appsets.ServiceClient)) managed.ExternalClient {
-	conn, argocdClient := newArgocdClientFn()
-	return &external{client: argocdClient, conn: conn}
+func NewExternal(newArgocdClientFn func() (io.Closer, appsets.ServiceClient, error)) (managed.ExternalClient, error) {
+	conn, argocdClient, err := newArgocdClientFn()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
+	return &external{client: argocdClient, conn: conn}, nil
 }
 
 type external struct {

--- a/pkg/controller/cluster/cluster/controller.go
+++ b/pkg/controller/cluster/cluster/controller.go
@@ -106,14 +106,17 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	return NewExternal(c.kube, func() (io.Closer, cluster.ServiceClient) {
+	return NewExternal(c.kube, func() (io.Closer, cluster.ServiceClient, error) {
 		return cluster.NewClusterServiceClient(cfg)
-	}), nil
+	})
 }
 
-func NewExternal(kube client.Client, newArgocdClientFn func() (io.Closer, cluster.ServiceClient)) managed.ExternalClient {
-	conn, argocdClient := newArgocdClientFn()
-	return &external{client: argocdClient, conn: conn}
+func NewExternal(kube client.Client, newArgocdClientFn func() (io.Closer, cluster.ServiceClient, error)) (managed.ExternalClient, error) {
+	conn, argocdClient, err := newArgocdClientFn()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
+	return &external{client: argocdClient, conn: conn}, nil
 }
 
 type external struct {

--- a/pkg/controller/cluster/projects/controller.go
+++ b/pkg/controller/cluster/projects/controller.go
@@ -87,7 +87,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -99,7 +99,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
+	conn, argocdClient, err := c.newArgocdClientFn(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
 	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
 }
 

--- a/pkg/controller/cluster/repositories/controller.go
+++ b/pkg/controller/cluster/repositories/controller.go
@@ -90,7 +90,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -102,7 +102,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
+	conn, argocdClient, err := c.newArgocdClientFn(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
 	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
 }
 

--- a/pkg/controller/cluster/tokens/controller.go
+++ b/pkg/controller/cluster/tokens/controller.go
@@ -72,7 +72,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -84,7 +84,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
+	conn, argocdClient, err := c.newArgocdClientFn(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
 	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
 }
 

--- a/pkg/controller/namespace/applications/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/applications/zz_generated.copied.controller.go
@@ -92,7 +92,7 @@ func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec man
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, applications.ServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, applications.ServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -104,14 +104,17 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	return NewExternal(func() (io.Closer, applications.ServiceClient) {
+	return NewExternal(func() (io.Closer, applications.ServiceClient, error) {
 		return c.newArgocdClientFn(cfg)
-	}), nil
+	})
 }
 
-func NewExternal(newArgocdClientFn func() (io.Closer, applications.ServiceClient)) managed.ExternalClient {
-	conn, argocdClient := newArgocdClientFn()
-	return &external{client: argocdClient, conn: conn}
+func NewExternal(newArgocdClientFn func() (io.Closer, applications.ServiceClient, error)) (managed.ExternalClient, error) {
+	conn, argocdClient, err := newArgocdClientFn()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
+	return &external{client: argocdClient, conn: conn}, nil
 }
 
 type external struct {

--- a/pkg/controller/namespace/applicationsets/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/applicationsets/zz_generated.copied.controller.go
@@ -106,14 +106,17 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, err
 	}
 
-	return NewExternal(func() (io.Closer, appsets.ServiceClient) {
+	return NewExternal(func() (io.Closer, appsets.ServiceClient, error) {
 		return appsets.NewApplicationSetServiceClient(cfg)
-	}), nil
+	})
 }
 
-func NewExternal(newArgocdClientFn func() (io.Closer, appsets.ServiceClient)) managed.ExternalClient {
-	conn, argocdClient := newArgocdClientFn()
-	return &external{client: argocdClient, conn: conn}
+func NewExternal(newArgocdClientFn func() (io.Closer, appsets.ServiceClient, error)) (managed.ExternalClient, error) {
+	conn, argocdClient, err := newArgocdClientFn()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
+	return &external{client: argocdClient, conn: conn}, nil
 }
 
 type external struct {

--- a/pkg/controller/namespace/cluster/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/cluster/zz_generated.copied.controller.go
@@ -108,14 +108,17 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	return NewExternal(c.kube, func() (io.Closer, cluster.ServiceClient) {
+	return NewExternal(c.kube, func() (io.Closer, cluster.ServiceClient, error) {
 		return cluster.NewClusterServiceClient(cfg)
-	}), nil
+	})
 }
 
-func NewExternal(kube client.Client, newArgocdClientFn func() (io.Closer, cluster.ServiceClient)) managed.ExternalClient {
-	conn, argocdClient := newArgocdClientFn()
-	return &external{client: argocdClient, conn: conn}
+func NewExternal(kube client.Client, newArgocdClientFn func() (io.Closer, cluster.ServiceClient, error)) (managed.ExternalClient, error) {
+	conn, argocdClient, err := newArgocdClientFn()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
+	return &external{client: argocdClient, conn: conn}, nil
 }
 
 type external struct {

--- a/pkg/controller/namespace/projects/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/projects/zz_generated.copied.controller.go
@@ -89,7 +89,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -101,7 +101,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
+	conn, argocdClient, err := c.newArgocdClientFn(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
 	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
 }
 

--- a/pkg/controller/namespace/repositories/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/repositories/zz_generated.copied.controller.go
@@ -92,7 +92,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -104,7 +104,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
+	conn, argocdClient, err := c.newArgocdClientFn(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
 	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
 }
 

--- a/pkg/controller/namespace/tokens/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/tokens/zz_generated.copied.controller.go
@@ -74,7 +74,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -86,7 +86,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
+	conn, argocdClient, err := c.newArgocdClientFn(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
 	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
 }
 


### PR DESCRIPTION
### Description of your changes

Today the argocd client constructors used by every managed-resource controller (`applications`, `applicationsets`, `projects`, `repositories`, `clusters`, `tokens`) call argo-cd's `NewClientOrDie` / `NewApplicationClientOrDie` / etc. variants. These `panic` on any error returned by argo-cd's eager DNS + TLS validation. Because the panic happens on the goroutine running the reconciler, **a single transient DNS failure** (NXDOMAIN, conntrack UDP race, brief CoreDNS unresponsiveness, etc.) **crashes the whole controller process.**

The two surface points:

1. `pkg/clients/cluster/argocd.go` — `NewClient` calls `argocd.NewClient` and then `panic(err)` on failure.
2. `pkg/clients/interface/*/client.go` (6 files) — each `NewXServiceClient` factory uses `apiclient.NewClientOrDie(...).NewXClientOrDie()`. These are invoked from `connector.Connect()` for every reconcile.

### What this PR changes

* `pkg/clients/cluster/argocd.go` — `NewClient` returns `(*argocd.Client, error)` instead of panicking.
* `pkg/clients/interface/{applications,applicationsets,cluster,clusters,projects,repositories}/client.go` — each `NewXServiceClient` factory now returns `(io.Closer, ServiceClient, error)`. Implementations use the non-`OrDie` variants from argo-cd (`apiclient.NewClient` and `Client.NewXClient`) and propagate any error.
* `pkg/controller/cluster/{applications,applicationsets,cluster,projects,repositories,tokens}/controller.go` — `connector.Connect` (and `NewExternal`, where present) now propagates the client-construction error so controller-runtime retries the reconcile with backoff instead of the controller process exiting.
* `pkg/controller/namespace/*/zz_generated.copied.controller.go` — regenerated from the updated cluster-scoped controllers.

Happy-path behaviour is unchanged: the same gRPC connection and service client are returned when the underlying argo-cd client constructs cleanly.

Fixes # <!-- happy to file a corresponding GH issue against this repo if maintainers prefer -->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `go build ./...` and `go test ./...` — all existing tests pass.
- [ ] Run `make reviewable test` — no such target in this repo's Makefile; ran the underlying go tooling instead.

### How has this code been tested

* `go build ./...` clean.
* `go test ./...` — all existing unit tests pass under both `pkg/controller/cluster/...` and the generated `pkg/controller/namespace/...` mirrors.
* `go vet ./...` clean.
* The namespace-scoped `zz_generated.copied.controller.go` files were regenerated via `go generate ./pkg/controller/namespace/...` after the cluster-scoped controllers were updated; the in-tree `sed -i ...` substitutions were applied manually with BSD-compatible syntax to confirm the output matches what GNU sed would produce in CI.
