### PR TITLE
[Backport release-0.14] fix: return errors instead of panicking when argocd client fails

### DIFF
--- a/pkg/clients/applications/client.go
+++ b/pkg/clients/applications/client.go
@@ -33,10 +33,20 @@ type ServiceClient interface {
 	Delete(ctx context.Context, in *application.ApplicationDeleteRequest, opts ...grpc.CallOption) (*application.ApplicationResponse, error)
 }
 
-// NewApplicationServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewApplicationServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, ServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewApplicationClientOrDie()
-	return conn, repoIf
+// NewApplicationServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the application gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewApplicationServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, ServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewApplicationClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorApplicationNotFound helper function to test for errorNotFound error.

--- a/pkg/clients/applicationsets/client.go
+++ b/pkg/clients/applicationsets/client.go
@@ -24,10 +24,20 @@ type ServiceClient interface {
 	Delete(ctx context.Context, in *applicationset.ApplicationSetDeleteRequest, opts ...grpc.CallOption) (*applicationset.ApplicationSetResponse, error)
 }
 
-// NewApplicationSetServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewApplicationSetServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, ServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewApplicationSetClientOrDie()
-	return conn, repoIf
+// NewApplicationSetServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the application-set gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewApplicationSetServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, ServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewApplicationSetClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsNotFound returns true if the error code is NotFound

--- a/pkg/clients/argocd.go
+++ b/pkg/clients/argocd.go
@@ -35,16 +35,17 @@ import (
 	"github.com/crossplane-contrib/provider-argocd/apis/v1alpha1"
 )
 
-// NewClient creates new argocd Client with provided argocd Configurations/Credentials.
-func NewClient(opts *argocd.ClientOptions) *argocd.Client {
-	var cl argocd.Client
-	var err error
-	cl, err = argocd.NewClient(opts)
-
+// NewClient creates new argocd Client with provided argocd
+// Configurations/Credentials. Any error from constructing the underlying
+// argo-cd client (for example, a transient DNS failure while resolving the
+// server address) is returned to the caller so the reconciler can retry with
+// backoff instead of panicking and crashing the controller process.
+func NewClient(opts *argocd.ClientOptions) (*argocd.Client, error) {
+	cl, err := argocd.NewClient(opts)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return &cl
+	return &cl, nil
 }
 
 // GetConfig constructs a Config that can be used to authenticate to argocd

--- a/pkg/clients/cluster/client.go
+++ b/pkg/clients/cluster/client.go
@@ -28,10 +28,20 @@ type ServiceClient interface {
 	Delete(ctx context.Context, in *cluster.ClusterQuery, opts ...grpc.CallOption) (*cluster.ClusterResponse, error)
 }
 
-// NewClusterServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewClusterServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, cluster.ClusterServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewClusterClientOrDie()
-	return conn, repoIf
+// NewClusterServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the cluster gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewClusterServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, cluster.ClusterServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewClusterClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorClusterNotFound helper function to test for errorClusterNotFound error.

--- a/pkg/clients/clusters/client.go
+++ b/pkg/clients/clusters/client.go
@@ -28,10 +28,20 @@ type ServiceClient interface {
 	Delete(ctx context.Context, in *cluster.ClusterQuery, opts ...grpc.CallOption) (*cluster.ClusterResponse, error)
 }
 
-// NewClusterServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewClusterServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, cluster.ClusterServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewClusterClientOrDie()
-	return conn, repoIf
+// NewClusterServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the cluster gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewClusterServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, cluster.ClusterServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewClusterClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorClusterNotFound helper function to test for errorClusterNotFound error.

--- a/pkg/clients/projects/client.go
+++ b/pkg/clients/projects/client.go
@@ -31,10 +31,20 @@ type ProjectServiceClient interface {
 	DeleteToken(ctx context.Context, in *project.ProjectTokenDeleteRequest, opts ...grpc.CallOption) (*project.EmptyResponse, error)
 }
 
-// NewProjectServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewProjectServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewProjectClientOrDie()
-	return conn, repoIf
+// NewProjectServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the project gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewProjectServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewProjectClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorProjectNotFound helper function to test for errorProjectNotFound error.

--- a/pkg/clients/repositories/client.go
+++ b/pkg/clients/repositories/client.go
@@ -30,10 +30,20 @@ type RepositoryServiceClient interface {
 	DeleteRepository(ctx context.Context, in *repository.RepoQuery, opts ...grpc.CallOption) (*repository.RepoResponse, error)
 }
 
-// NewRepositoryServiceClient creates a new API client from a set of config options, or fails fatally if the new client creation fails.
-func NewRepositoryServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient) {
-	conn, repoIf := apiclient.NewClientOrDie(clientOpts).NewRepoClientOrDie()
-	return conn, repoIf
+// NewRepositoryServiceClient creates a new API client from a set of config
+// options. Any error from constructing the underlying argo-cd client or
+// opening the repository gRPC connection is returned to the caller so the
+// reconciler can retry with backoff instead of crashing the controller process.
+func NewRepositoryServiceClient(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient, error) {
+	client, err := apiclient.NewClient(clientOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	conn, repoIf, err := client.NewRepoClient()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, repoIf, nil
 }
 
 // IsErrorRepositoryNotFound helper function to test for errorRepositoryNotFound error.

--- a/pkg/controller/applications/controller.go
+++ b/pkg/controller/applications/controller.go
@@ -86,7 +86,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, applications.ServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, applications.ServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -98,13 +98,20 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
+	return NewExternal(func() (io.Closer, applications.ServiceClient, error) {
+		return c.newArgocdClientFn(cfg)
+	})
+}
 
-	conn, argocdClient := c.newArgocdClientFn(cfg)
-	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
+func NewExternal(newArgocdClientFn func() (io.Closer, applications.ServiceClient, error)) (managed.ExternalClient, error) {
+	conn, argocdClient, err := newArgocdClientFn()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
+	return &external{client: argocdClient, conn: conn}, nil
 }
 
 type external struct {
-	kube   client.Client
 	client applications.ServiceClient
 	conn   io.Closer
 }

--- a/pkg/controller/applicationsets/controller.go
+++ b/pkg/controller/applicationsets/controller.go
@@ -83,7 +83,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, appsets.ServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, appsets.ServiceClient, error)
 }
 
 // Connect typically produces an ExternalClient by:
@@ -102,12 +102,20 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, err
 	}
 
-	conn, argocdClient := c.newArgocdClientFn(cfg)
-	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
+	return NewExternal(func() (io.Closer, appsets.ServiceClient, error) {
+		return appsets.NewApplicationSetServiceClient(cfg)
+	})
+}
+
+func NewExternal(newArgocdClientFn func() (io.Closer, appsets.ServiceClient, error)) (managed.ExternalClient, error) {
+	conn, argocdClient, err := newArgocdClientFn()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
+	return &external{client: argocdClient, conn: conn}, nil
 }
 
 type external struct {
-	kube   client.Client
 	client appsets.ServiceClient
 	conn   io.Closer
 }

--- a/pkg/controller/cluster/controller.go
+++ b/pkg/controller/cluster/controller.go
@@ -93,7 +93,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, argocdcluster.ClusterServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, argocdcluster.ClusterServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -105,8 +105,17 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
-	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
+	return NewExternal(c.kube, func() (io.Closer, cluster.ServiceClient, error) {
+		return cluster.NewClusterServiceClient(cfg)
+	})
+}
+
+func NewExternal(kube client.Client, newArgocdClientFn func() (io.Closer, cluster.ServiceClient, error)) (managed.ExternalClient, error) {
+	conn, argocdClient, err := newArgocdClientFn()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
+	return &external{client: argocdClient, conn: conn}, nil
 }
 
 type external struct {

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -33,6 +33,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 	of := resource.ProviderConfigKinds{
 		Config:    v1alpha1.ProviderConfigGroupVersionKind,
+		Usage:     v1alpha1.ProviderConfigUsageGroupVersionKind,
 		UsageList: v1alpha1.ProviderConfigUsageListGroupVersionKind,
 	}
 

--- a/pkg/controller/projects/controller.go
+++ b/pkg/controller/projects/controller.go
@@ -87,7 +87,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -99,7 +99,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
+	conn, argocdClient, err := c.newArgocdClientFn(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
 	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
 }
 

--- a/pkg/controller/repositories/controller.go
+++ b/pkg/controller/repositories/controller.go
@@ -90,7 +90,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, repository.RepositoryServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -102,7 +102,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
+	conn, argocdClient, err := c.newArgocdClientFn(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
 	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
 }
 

--- a/pkg/controller/tokens/controller.go
+++ b/pkg/controller/tokens/controller.go
@@ -72,7 +72,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 
 type connector struct {
 	kube              client.Client
-	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient)
+	newArgocdClientFn func(clientOpts *apiclient.ClientOptions) (io.Closer, project.ProjectServiceClient, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -84,7 +84,10 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if err != nil {
 		return nil, err
 	}
-	conn, argocdClient := c.newArgocdClientFn(cfg)
+	conn, argocdClient, err := c.newArgocdClientFn(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create argocd client")
+	}
 	return &external{kube: c.kube, client: argocdClient, conn: conn}, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Backport of https://github.com/crossplane-contrib/provider-argocd/pull/359

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
