### PR TITLE
[Backport release-0.14] fix(cluster): assign kube client in NewExternal

### DIFF
--- a/pkg/controller/cluster/controller.go
+++ b/pkg/controller/cluster/controller.go
@@ -115,7 +115,7 @@ func NewExternal(kube client.Client, newArgocdClientFn func() (io.Closer, cluste
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create argocd client")
 	}
-	return &external{client: argocdClient, conn: conn}, nil
+	return &external{kube: kube, client: argocdClient, conn: conn}, nil
 }
 
 type external struct {


### PR DESCRIPTION
Signed-off-by: MisterMX <mbxd12@web.de>
(cherry picked from commit e9f592c)<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Backport of https://github.com/crossplane-contrib/provider-argocd/pull/363

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
