### PR TITLE
chore: bump Go to 1.26.5 and golangci-lint to v2.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25.1'
-  GOLANGCI_VERSION: 'v2.4.0'
+  GO_VERSION: '1.26.5'
+  GOLANGCI_VERSION: 'v2.9.0'
   DOCKER_BUILDX_VERSION: 'v0.14.1'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run

--- a/apis/cluster/applications/v1alpha1/status.go
+++ b/apis/cluster/applications/v1alpha1/status.go
@@ -21,6 +21,7 @@ type ArgoApplicationStatus struct {
 	// OperationState contains information about any ongoing operations, such as a sync
 	OperationState *OperationState `json:"operationState,omitempty" protobuf:"bytes,7,opt,name=operationState"`
 	// ObservedAt indicates when the application state was updated without querying latest git state
+	//
 	// Deprecated: controller no longer updates ObservedAt field
 	ObservedAt *metav1.Time `json:"observedAt,omitempty" protobuf:"bytes,8,opt,name=observedAt"`
 	// SourceType specifies the type of this application

--- a/apis/namespace/applications/v1alpha1/zz_generated.types.copied.go
+++ b/apis/namespace/applications/v1alpha1/zz_generated.types.copied.go
@@ -459,6 +459,7 @@ type ArgoApplicationStatus struct {
 	// OperationState contains information about any ongoing operations, such as a sync
 	OperationState *OperationState `json:"operationState,omitempty" protobuf:"bytes,7,opt,name=operationState"`
 	// ObservedAt indicates when the application state was updated without querying latest git state
+	//
 	// Deprecated: controller no longer updates ObservedAt field
 	ObservedAt *metav1.Time `json:"observedAt,omitempty" protobuf:"bytes,8,opt,name=observedAt"`
 	// SourceType specifies the type of this application

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/provider-argocd
 
-go 1.24.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/package/crds/applications.argocd.crossplane.io_applications.yaml
+++ b/package/crds/applications.argocd.crossplane.io_applications.yaml
@@ -2246,6 +2246,7 @@ spec:
                   observedAt:
                     description: |-
                       ObservedAt indicates when the application state was updated without querying latest git state
+
                       Deprecated: controller no longer updates ObservedAt field
                     format: date-time
                     type: string

--- a/package/crds/applications.m.argocd.crossplane.io_applications.yaml
+++ b/package/crds/applications.m.argocd.crossplane.io_applications.yaml
@@ -2216,6 +2216,7 @@ spec:
                   observedAt:
                     description: |-
                       ObservedAt indicates when the application state was updated without querying latest git state
+
                       Deprecated: controller no longer updates ObservedAt field
                     format: date-time
                     type: string

--- a/pkg/controller/cluster/applications/controller.go
+++ b/pkg/controller/cluster/applications/controller.go
@@ -62,7 +62,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec managed.ExternalConnecter) error {
 	name := managed.ControllerName(v1alpha1.ApplicationKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(ec),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
@@ -71,9 +71,7 @@ func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec man
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.ApplicationList{}); err != nil {
 		return err

--- a/pkg/controller/cluster/applicationsets/controller.go
+++ b/pkg/controller/cluster/applicationsets/controller.go
@@ -58,7 +58,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec managed.ExternalConnecter) error {
 	name := managed.ControllerName(v1alpha1.ApplicationSetKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(ec),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
@@ -67,9 +67,7 @@ func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec man
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.ApplicationSetList{}); err != nil {
 		return err

--- a/pkg/controller/cluster/cluster/controller.go
+++ b/pkg/controller/cluster/cluster/controller.go
@@ -67,7 +67,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec managed.ExternalConnecter) error {
 	name := managed.ControllerName(v1alpha1.ClusterKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(ec),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
@@ -76,9 +76,7 @@ func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec man
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.ClusterList{}); err != nil {
 		return err

--- a/pkg/controller/cluster/projects/controller.go
+++ b/pkg/controller/cluster/projects/controller.go
@@ -56,7 +56,7 @@ const (
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.ProjectKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{
 			kube:              mgr.GetClient(),
 			newArgocdClientFn: projects.NewProjectServiceClient,
@@ -68,9 +68,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.ProjectList{}); err != nil {
 		return err

--- a/pkg/controller/cluster/repositories/controller.go
+++ b/pkg/controller/cluster/repositories/controller.go
@@ -59,7 +59,7 @@ const (
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.RepositoryKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{
 			kube:              mgr.GetClient(),
 			newArgocdClientFn: repositories.NewRepositoryServiceClient,
@@ -71,9 +71,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.RepositoryList{}); err != nil {
 		return err

--- a/pkg/controller/cluster/tokens/controller.go
+++ b/pkg/controller/cluster/tokens/controller.go
@@ -41,7 +41,7 @@ const (
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.TokenKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{
 			kube:              mgr.GetClient(),
 			newArgocdClientFn: projects.NewProjectServiceClient,
@@ -53,9 +53,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.TokenList{}); err != nil {
 		return err

--- a/pkg/controller/namespace/applications/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/applications/zz_generated.copied.controller.go
@@ -64,7 +64,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec managed.ExternalConnecter) error {
 	name := managed.ControllerName(v1alpha1.ApplicationKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(ec),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
@@ -73,9 +73,7 @@ func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec man
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.ApplicationList{}); err != nil {
 		return err

--- a/pkg/controller/namespace/applicationsets/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/applicationsets/zz_generated.copied.controller.go
@@ -60,7 +60,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec managed.ExternalConnecter) error {
 	name := managed.ControllerName(v1alpha1.ApplicationSetKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(ec),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
@@ -69,9 +69,7 @@ func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec man
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.ApplicationSetList{}); err != nil {
 		return err

--- a/pkg/controller/namespace/cluster/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/cluster/zz_generated.copied.controller.go
@@ -69,7 +69,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec managed.ExternalConnecter) error {
 	name := managed.ControllerName(v1alpha1.ClusterKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(ec),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
@@ -78,9 +78,7 @@ func SetupWithExternalConnector(mgr ctrl.Manager, o xpcontroller.Options, ec man
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.ClusterList{}); err != nil {
 		return err

--- a/pkg/controller/namespace/projects/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/projects/zz_generated.copied.controller.go
@@ -58,7 +58,7 @@ const (
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.ProjectKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{
 			kube:              mgr.GetClient(),
 			newArgocdClientFn: projects.NewProjectServiceClient,
@@ -70,9 +70,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.ProjectList{}); err != nil {
 		return err

--- a/pkg/controller/namespace/repositories/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/repositories/zz_generated.copied.controller.go
@@ -61,7 +61,7 @@ const (
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.RepositoryKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{
 			kube:              mgr.GetClient(),
 			newArgocdClientFn: repositories.NewRepositoryServiceClient,
@@ -73,9 +73,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.RepositoryList{}); err != nil {
 		return err

--- a/pkg/controller/namespace/tokens/zz_generated.copied.controller.go
+++ b/pkg/controller/namespace/tokens/zz_generated.copied.controller.go
@@ -43,7 +43,7 @@ const (
 func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.TokenKind)
 
-	opts := []managed.ReconcilerOption{
+	opts := append([]managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{
 			kube:              mgr.GetClient(),
 			newArgocdClientFn: projects.NewProjectServiceClient,
@@ -55,9 +55,7 @@ func Setup(mgr ctrl.Manager, o xpcontroller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithTimeout(5 * time.Minute),
 		managed.WithMetricRecorder(o.MetricOptions.MRMetrics),
-	}
-
-	opts = append(opts, (features.Opts(o))...)
+	}, (features.Opts(o))...)
 
 	if err := features.AddMRMetrics(mgr, o, &v1alpha1.TokenList{}); err != nil {
 		return err


### PR DESCRIPTION
### Description of your changes

Bumps the project's Go version to 1.26.5, along with the two CI pins that are coupled to it.

**Version bumps**

- `go.mod`: `go 1.24.4` → `1.26.5`
- `.github/workflows/ci.yml`: `GO_VERSION` `1.25.1` → `1.26.5`. CI was provisioning an older toolchain than `go.mod` declares, forcing every job into an implicit toolchain download.
- `.github/workflows/ci.yml`: `GOLANGCI_VERSION` `v2.4.0` → `v2.9.0`

The golangci-lint bump is required, not incidental. golangci-lint refuses to analyse a module targeting a newer Go than it was compiled against:

```
can't load config: the Go language version (go1.25) used to build golangci-lint
is lower than the targeted Go version (1.26.5)
```

v2.4.0 is built with go1.25, so the lint job fails before inspecting any code. v2.9.0 is the earliest release built with Go 1.26. It was chosen deliberately over the latest release (v2.12.2) to keep unrelated churn out of a version bump — v2.12.2 additionally reports 5 pre-existing `goconst` findings in test files.

**Lint fixes required by the above**

The newer linter surfaces 7 pre-existing findings. These are style-only, with no behavioural change:

- `prealloc` (×6): folded a trailing `append` into the slice literal in each `pkg/controller/cluster/*/controller.go`. Same reconciler options, one fewer allocation.
- `gocritic/deprecatedComment` (×1): added a paragraph break before the `Deprecated:` marker in `apis/cluster/applications/v1alpha1/status.go`, so the notice is recognised by tooling.

**Generated files**

The remaining 6 files are machine-generated and committed only to satisfy `make check-diff`. `copystruct` mirrors the cluster-scoped controllers into their namespace-scoped equivalents, so the 6 `prealloc` fixes propagate to `pkg/controller/namespace/*/zz_generated.copied.controller.go`. The doc comment change likewise flows into the copied types and adds a single blank line to a `description` field in two CRD manifests — no schema change.

No functional changes to the provider.

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`make reviewable test` passes locally on Go 1.26.5 (exit 0), covering code generation, lint under golangci-lint v2.9.0, and the full unit test suite.

`make generate` was additionally run to confirm the committed generated output is idempotent. `go build ./...` and `go vet ./...` are clean.

No new tests were added; the change carries no behavioural difference, and existing coverage of the affected controllers is unchanged.
